### PR TITLE
fix: fix queue and matcher errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jest-mq",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jest-mq",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "jest-matcher-utils": "^30.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-mq",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Jest framework for testing message queues like RabbitMQ and Kafka.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/queue.spec.ts
+++ b/src/__tests__/queue.spec.ts
@@ -94,6 +94,12 @@ describe("MessageQueue", () => {
       expect(receivedMessage).toBeUndefined();
     });
 
+    it("should not mutate received messages when queue is empty", () => {
+      queue.receiveMessage();
+      expect(queue.getQueue().receivedMessages).toHaveLength(0);
+      expect(queue.getQueue().sentMessages).toHaveLength(0);
+    });
+
     it("should return undefined if no matching messages are available", () => {
       queue.publish({ type: "otherType", payload: "test" });
       const receivedMessage = queue.receiveMessage("nonExistentType");
@@ -175,6 +181,16 @@ describe("MessageQueue", () => {
         ...message,
         id: expect.any(Number),
       });
+    });
+
+    it("should only call default handlers once when type is undefined", async () => {
+      const defaultHandler = jest.fn();
+      queue.subscribe(undefined, defaultHandler);
+
+      queue.publish({ type: undefined, data: "no type" });
+
+      await queue.flush();
+      expect(defaultHandler).toHaveBeenCalledTimes(1);
     });
 
     it("should handle asynchronous handlers", async () => {

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -49,7 +49,9 @@ export class MessageQueue<T = any> {
   private async processHandlers(messageWithId: Message<T>): Promise<void> {
     const typedHandlers = this.handlers.get(messageWithId.type) || [];
     const defaultHandlers =
-      messageWithId.type === undefined ? [] : this.handlers.get(undefined) || [];
+      messageWithId.type === undefined
+        ? []
+        : this.handlers.get(undefined) || [];
     const handlers = [...typedHandlers, ...defaultHandlers];
 
     const processing = Promise.all(

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -47,10 +47,10 @@ export class MessageQueue<T = any> {
   }
 
   private async processHandlers(messageWithId: Message<T>): Promise<void> {
-    const handlers = [
-      ...(this.handlers.get(messageWithId.type) || []),
-      ...(this.handlers.get(undefined) || []),
-    ];
+    const typedHandlers = this.handlers.get(messageWithId.type) || [];
+    const defaultHandlers =
+      messageWithId.type === undefined ? [] : this.handlers.get(undefined) || [];
+    const handlers = [...typedHandlers, ...defaultHandlers];
 
     const processing = Promise.all(
       handlers.map((handler) =>
@@ -82,7 +82,9 @@ export class MessageQueue<T = any> {
   receiveMessage(messageType?: string, autoAck = true): Message<T> | undefined {
     const messageIndex = messageType
       ? this.sentMessages.findIndex((m) => m.type === messageType)
-      : 0;
+      : this.sentMessages.length > 0
+        ? 0
+        : -1;
     if (messageIndex === -1) {
       return undefined;
     }

--- a/src/matchers/toBeInQueue.ts
+++ b/src/matchers/toBeInQueue.ts
@@ -19,14 +19,14 @@ export const toBeInQueue = function (
     pass: messageIsInQueue,
     message: () => {
       const hint = matcherHint(".toBeInQueue", "received", "expectedMessage");
-      const receivedStr = printReceived(expectedMessage);
-      const expectedStr = printExpected(queue.sentMessages);
+      const expectedStr = printExpected(expectedMessage);
+      const receivedStr = printReceived(queue.sentMessages);
       return `${hint}
       
       Expected message to be in queue:
-        ${receivedStr}
+        ${expectedStr}
       Received:
-        ${expectedStr}`;
+        ${receivedStr}`;
     },
   };
 };


### PR DESCRIPTION
# Changes

- fixed guards when empty-queue reads, and avoids double-invoking default handlers for undefined types
- fixed correct expected and received message output in toBeInQueue matcher