### PR TITLE
feat: add DLQ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,39 @@ const queue = new MessageQueue<MyMessage>("queue-name");
 | `receiveMessage(type?, autoAck?)` | Dequeues the first matching message. `autoAck` defaults to `true`. |
 | `peek(type?)` | Reads the first matching message without consuming it (`autoAck = false`). |
 | `ack(message)` | Explicitly acknowledges a message received with `autoAck = false`. |
+| `nack(message)` | Moves a message from the main queue into the dead letter queue. |
 | `subscribe(type, handler)` | Registers a handler for a message type (or `undefined` for all types). Returns an unsubscribe function. |
 | `flush()` | Awaits all pending handler executions. Throws `AggregateError` if any handler threw. |
 | `clear()` | Resets all queue state. |
+
+#### Dead letter queue
+
+Pass `{ autoDeadLetter: true }` to automatically move a message to the DLQ when its handler throws:
+
+```ts
+const queue = new MessageQueue<MyMessage>("orders", { autoDeadLetter: true });
+
+queue.subscribe("order.created", async (message) => {
+  if (!message.orderId) throw new Error("invalid message");
+  // ...
+});
+
+queue.publish({ type: "order.created" }); // no orderId — handler throws
+
+try {
+  await queue.flush();
+} catch { /* AggregateError still thrown */ }
+
+expect(queue).toBeInDeadLetterQueue({ type: "order.created" });
+```
+
+You can also dead-letter messages manually:
+
+```ts
+const msg = queue.peek("order.created")!;
+queue.nack(msg);
+expect(queue).toHaveDeadLetterQueueSize(1);
+```
 
 ### `MessageQueueAdapter<T>`
 
@@ -197,9 +227,26 @@ Asserts a specific message was published exactly `n` times across all sent and r
 expect(queue).toHavePublishedTimes({ type: "order.created", orderId: "x" }, 2);
 ```
 
+### `toBeInDeadLetterQueue(expectedMessage)`
+
+Asserts a message is in the dead letter queue (dead-lettered via `nack()` or `autoDeadLetter`).
+
+```ts
+queue.nack(queue.peek("order.created")!);
+expect(queue).toBeInDeadLetterQueue({ type: "order.created", orderId: "order-123" });
+```
+
+### `toHaveDeadLetterQueueSize(n)`
+
+Asserts the number of messages in the dead letter queue.
+
+```ts
+expect(queue).toHaveDeadLetterQueueSize(1);
+```
+
 ## Scope and non-goals
 
 - This is a deterministic test double plus matchers, not a full MQ emulator.
 - `MessageQueue` models publish/subscribe and handler flushing.
-- TODO: retries, DLQs, ordering guarantees, and other broker behaviors.
+- TODO: retries, ordering guarantees, and other broker behaviors.
 - This is meant for unit tests; integration tests should run against a real broker.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jest-mq",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jest-mq",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "jest-matcher-utils": "^30.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-mq",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "A Jest framework for testing message queues like RabbitMQ and Kafka.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/__snapshots__/toBeInDeadLetterQueue.spec.ts.snap
+++ b/src/__tests__/__snapshots__/toBeInDeadLetterQueue.spec.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`toBeInDeadLetterQueue should fail if message is not in dead letter queue 1`] = `
+"expect(received).toBeInDeadLetterQueue(expectedMessage)
+
+      Expected message to be in dead letter queue:
+        {"payload": "test", "type": "test"}
+      Received:
+        []"
+`;

--- a/src/__tests__/__snapshots__/toHaveDeadLetterQueueSize.spec.ts.snap
+++ b/src/__tests__/__snapshots__/toHaveDeadLetterQueueSize.spec.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`toHaveDeadLetterQueueSize should fail if dead letter queue size does not match 1`] = `
+"expect(received).toHaveDeadLetterQueueSize(expectedCount)
+
+      Expected dead letter queue size:
+        2
+      Received:
+        1
+      Dead letter queue contents:
+        [{"id": 0, "payload": "test", "type": "test"}]"
+`;

--- a/src/__tests__/queue.spec.ts
+++ b/src/__tests__/queue.spec.ts
@@ -279,6 +279,61 @@ describe("MessageQueue", () => {
     });
   });
 
+  describe("nack", () => {
+    it("should move a message to deadLetterMessages", () => {
+      queue.publish({ type: "test", payload: "test" });
+      const message = queue.peek("test")!;
+
+      queue.nack(message);
+
+      expect(queue.getQueue().sentMessages).toHaveLength(0);
+      expect(queue.getQueue().deadLetterMessages).toHaveLength(1);
+    });
+
+    it("should be a no-op when message is not in sentMessages", () => {
+      queue.publish({ type: "test", payload: "test" });
+      const message = queue.receiveMessage("test")!;
+
+      queue.nack(message);
+
+      expect(queue.getQueue().deadLetterMessages).toHaveLength(0);
+    });
+
+    it("should auto-nack on handler failure when autoDeadLetter is true", async () => {
+      const dlqQueue = new MessageQueue("dlq-test", { autoDeadLetter: true });
+      dlqQueue.subscribe("badMessage", () => {
+        throw new Error("processing failed");
+      });
+
+      dlqQueue.publish({ type: "badMessage" });
+
+      try {
+        await dlqQueue.flush();
+      } catch {
+        // expected
+      }
+
+      expect(dlqQueue.getQueue().deadLetterMessages).toHaveLength(1);
+      dlqQueue.clear();
+    });
+
+    it("should not auto-nack on handler failure by default", async () => {
+      queue.subscribe("badMessage", () => {
+        throw new Error("processing failed");
+      });
+
+      queue.publish({ type: "badMessage" });
+
+      try {
+        await queue.flush();
+      } catch {
+        // expected
+      }
+
+      expect(queue.getQueue().deadLetterMessages).toHaveLength(0);
+    });
+  });
+
   describe("flush", () => {
     it("should surface handler errors", async () => {
       const handler = jest.fn(() => {

--- a/src/__tests__/toBeInDeadLetterQueue.spec.ts
+++ b/src/__tests__/toBeInDeadLetterQueue.spec.ts
@@ -1,0 +1,28 @@
+import "../matchers";
+import { MessageQueue } from "../core/queue";
+
+describe("toBeInDeadLetterQueue", () => {
+  let queue: MessageQueue;
+
+  beforeEach(() => {
+    queue = new MessageQueue("test");
+  });
+
+  afterEach(() => {
+    queue.clear();
+  });
+
+  it("should pass if message is in dead letter queue", () => {
+    const message = { type: "test", payload: "test" };
+    queue.publish(message);
+    queue.nack(queue.peek("test")!);
+    expect(queue).toBeInDeadLetterQueue(message);
+  });
+
+  it("should fail if message is not in dead letter queue", () => {
+    const message = { type: "test", payload: "test" };
+    expect(() =>
+      expect(queue).toBeInDeadLetterQueue(message),
+    ).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/__tests__/toHaveDeadLetterQueueSize.spec.ts
+++ b/src/__tests__/toHaveDeadLetterQueueSize.spec.ts
@@ -1,0 +1,31 @@
+import "../matchers";
+import { MessageQueue } from "../core/queue";
+
+describe("toHaveDeadLetterQueueSize", () => {
+  let queue: MessageQueue;
+
+  beforeEach(() => {
+    queue = new MessageQueue("test");
+  });
+
+  afterEach(() => {
+    queue.clear();
+  });
+
+  it("should pass if dead letter queue size matches", () => {
+    expect(queue).toHaveDeadLetterQueueSize(0);
+    queue.publish({ type: "test", payload: "first" });
+    queue.publish({ type: "test", payload: "second" });
+    queue.nack(queue.peek("test")!);
+    queue.nack(queue.peek("test")!);
+    expect(queue).toHaveDeadLetterQueueSize(2);
+  });
+
+  it("should fail if dead letter queue size does not match", () => {
+    queue.publish({ type: "test", payload: "test" });
+    queue.nack(queue.peek("test")!);
+    expect(() =>
+      expect(queue).toHaveDeadLetterQueueSize(2),
+    ).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/core/adapter.ts
+++ b/src/core/adapter.ts
@@ -20,4 +20,5 @@ export interface MessageQueueAdapter<T = unknown> {
     messageType: string | undefined,
     handler: (message: T) => Promise<void> | void,
   ): () => void;
+  nack?(message: QueueMessage<T>): Promise<void> | void;
 }

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -20,12 +20,16 @@ export class MessageQueue<T extends MessagePayload = MessagePayload> {
   private sentMessages: Message<T>[] = [];
   private receivedMessages: Message<T>[] = [];
   private ackedMessages: Message<T>[] = [];
+  private deadLetterMessages: Message<T>[] = [];
   private handlers: Map<string | undefined, MessageHandler<T>[]> = new Map();
   private messageCount: number = 0;
   private pendingHandlers: Set<Promise<void>> = new Set();
   private handlerErrors: Error[] = [];
 
-  constructor(public name: string) {
+  constructor(
+    public name: string,
+    private options: { autoDeadLetter?: boolean } = {},
+  ) {
     if (!name) {
       throw new Error("Queue name is required");
     }
@@ -42,6 +46,7 @@ export class MessageQueue<T extends MessagePayload = MessagePayload> {
     sentMessages: Message<T>[];
     receivedMessages: Message<T>[];
     ackedMessages: Message<T>[];
+    deadLetterMessages: Message<T>[];
     handlers: Map<string | undefined, MessageHandler<T>[]>;
   } {
     return {
@@ -49,6 +54,7 @@ export class MessageQueue<T extends MessagePayload = MessagePayload> {
       sentMessages: [...this.sentMessages],
       receivedMessages: [...this.receivedMessages],
       ackedMessages: [...this.ackedMessages],
+      deadLetterMessages: [...this.deadLetterMessages],
       handlers: new Map(this.handlers),
     };
   }
@@ -57,6 +63,7 @@ export class MessageQueue<T extends MessagePayload = MessagePayload> {
     this.sentMessages = [];
     this.receivedMessages = [];
     this.ackedMessages = [];
+    this.deadLetterMessages = [];
     this.handlers.clear();
     this.messageCount = 0;
     this.pendingHandlers.clear();
@@ -79,6 +86,9 @@ export class MessageQueue<T extends MessagePayload = MessagePayload> {
             this.handlerErrors.push(
               error instanceof Error ? error : new Error(String(error)),
             );
+            if (this.options.autoDeadLetter) {
+              this.nack(messageWithId);
+            }
           }),
       ),
     ).then(() => undefined);
@@ -128,6 +138,13 @@ export class MessageQueue<T extends MessagePayload = MessagePayload> {
     const [ackedMessage] = this.sentMessages.splice(messageIndex, 1);
     this.receivedMessages.push(ackedMessage);
     this.ackedMessages.push(ackedMessage);
+  }
+
+  nack(message: Message<T>): void {
+    const idx = this.sentMessages.findIndex((m) => m.id === message.id);
+    if (idx === -1) return;
+    const [msg] = this.sentMessages.splice(idx, 1);
+    this.deadLetterMessages.push(msg);
   }
 
   peek(messageType?: string): Message<T> | undefined {

--- a/src/matchers/index.ts
+++ b/src/matchers/index.ts
@@ -1,9 +1,11 @@
 import { toBeInQueue } from "./toBeInQueue";
+import { toBeInDeadLetterQueue } from "./toBeInDeadLetterQueue";
 import { toHaveEmptyQueue } from "./toHaveEmptyQueue";
 import { toHaveBeenAcked } from "./toHaveBeenAcked";
 import { toHaveOnlyTypes } from "./toHaveOnlyTypes";
 import { toHavePublishedTimes } from "./toHavePublishedTimes";
 import { toHaveQueueSize } from "./toHaveQueueSize";
+import { toHaveDeadLetterQueueSize } from "./toHaveDeadLetterQueueSize";
 import { toHaveReceived } from "./toHaveReceived";
 import type { MessagePayload } from "../core/queue";
 
@@ -11,6 +13,7 @@ declare global {
   namespace jest {
     interface Matchers<R> {
       toBeInQueue(expectedMessage: MessagePayload): R;
+      toBeInDeadLetterQueue(expectedMessage: MessagePayload): R;
       toHaveEmptyQueue(): R;
       toHaveBeenAcked(expectedMessage: MessagePayload): R;
       toHaveOnlyTypes(expectedTypes: string[]): R;
@@ -19,6 +22,7 @@ declare global {
         expectedCount: number,
       ): R;
       toHaveQueueSize(expectedCount: number): R;
+      toHaveDeadLetterQueueSize(expectedCount: number): R;
       toHaveReceived(expectedMessage: MessagePayload): R;
     }
   }
@@ -26,10 +30,12 @@ declare global {
 
 expect.extend({
   toBeInQueue,
+  toBeInDeadLetterQueue,
   toHaveEmptyQueue,
   toHaveBeenAcked,
   toHaveOnlyTypes,
   toHavePublishedTimes,
   toHaveQueueSize,
+  toHaveDeadLetterQueueSize,
   toHaveReceived,
 });

--- a/src/matchers/toBeInDeadLetterQueue.ts
+++ b/src/matchers/toBeInDeadLetterQueue.ts
@@ -1,0 +1,32 @@
+import { MessageQueue, type MessagePayload } from "../core/queue";
+import { matcherHint, printReceived, printExpected } from "jest-matcher-utils";
+
+export const toBeInDeadLetterQueue = function (
+  this: jest.MatcherContext,
+  received: MessageQueue,
+  expectedMessage: MessagePayload,
+) {
+  const queue = received.getQueue();
+  const messageIsInDLQ = queue.deadLetterMessages.some((message) =>
+    this.equals({ ...message, id: undefined }, expectedMessage),
+  );
+
+  return {
+    pass: messageIsInDLQ,
+    message: () => {
+      const hint = matcherHint(
+        ".toBeInDeadLetterQueue",
+        "received",
+        "expectedMessage",
+      );
+      const expectedStr = printExpected(expectedMessage);
+      const receivedStr = printReceived(queue.deadLetterMessages);
+      return `${hint}
+
+      Expected message to be in dead letter queue:
+        ${expectedStr}
+      Received:
+        ${receivedStr}`;
+    },
+  };
+};

--- a/src/matchers/toHaveDeadLetterQueueSize.ts
+++ b/src/matchers/toHaveDeadLetterQueueSize.ts
@@ -1,0 +1,34 @@
+import { MessageQueue } from "../core/queue";
+import { matcherHint, printReceived, printExpected } from "jest-matcher-utils";
+
+export const toHaveDeadLetterQueueSize = function (
+  this: jest.MatcherContext,
+  received: MessageQueue,
+  expectedCount: number,
+) {
+  const queue = received.getQueue();
+  const actualCount = queue.deadLetterMessages.length;
+  const pass = actualCount === expectedCount;
+
+  return {
+    pass,
+    message: () => {
+      const hint = matcherHint(
+        ".toHaveDeadLetterQueueSize",
+        "received",
+        "expectedCount",
+      );
+      const expectedStr = printExpected(expectedCount);
+      const receivedStr = printReceived(actualCount);
+      const messagesStr = printReceived(queue.deadLetterMessages);
+      return `${hint}
+
+      Expected dead letter queue size:
+        ${expectedStr}
+      Received:
+        ${receivedStr}
+      Dead letter queue contents:
+        ${messagesStr}`;
+    },
+  };
+};


### PR DESCRIPTION
This pull request introduces support for dead letter queues (DLQs) to the `MessageQueue` testing utility, allowing messages that fail processing or are explicitly rejected to be tracked and asserted in tests. It adds both core functionality for dead-lettering messages and new Jest matchers to assert DLQ state, along with comprehensive documentation and tests.

The most important changes are:

**Dead Letter Queue Core Functionality:**
* Added a `deadLetterMessages` array to `MessageQueue`, with a new `nack` method for moving messages from the main queue to the DLQ. The queue can now be constructed with an `autoDeadLetter` option, which automatically dead-letters messages when their handler throws. [[1]](diffhunk://#diff-14567f467041c6cd00b9c9033211c73cfcce11ed0df130991f2ff4b93ab84f7cR23-R32) [[2]](diffhunk://#diff-14567f467041c6cd00b9c9033211c73cfcce11ed0df130991f2ff4b93ab84f7cR49-R57) [[3]](diffhunk://#diff-14567f467041c6cd00b9c9033211c73cfcce11ed0df130991f2ff4b93ab84f7cR66) [[4]](diffhunk://#diff-14567f467041c6cd00b9c9033211c73cfcce11ed0df130991f2ff4b93ab84f7cR89-R91) [[5]](diffhunk://#diff-14567f467041c6cd00b9c9033211c73cfcce11ed0df130991f2ff4b93ab84f7cR143-R149)
* Extended the `MessageQueueAdapter` interface to optionally support the `nack` method.

**Jest Matchers for DLQ:**
* Added new matchers: `toBeInDeadLetterQueue` (asserts a message is in the DLQ) and `toHaveDeadLetterQueueSize` (asserts the DLQ size), with corresponding implementation and type declarations. [[1]](diffhunk://#diff-5290f96d0554c66368ecc2d01fa31bdae88738b46a91fedbfa3e6e8bc506f50cR2-R16) [[2]](diffhunk://#diff-5290f96d0554c66368ecc2d01fa31bdae88738b46a91fedbfa3e6e8bc506f50cR25-R39) [[3]](diffhunk://#diff-fe7b1c8950030b6b606368e12fe99ad50fe74f712ff759e0c8fd1dd6f277553fR1-R32) [[4]](diffhunk://#diff-80b4d2a69c7aead5b51264470171e63394493d759b5ce6e5d0a966567367f521R1-R34)

**Documentation Updates:**
* Updated the `README.md` to document the new DLQ features, including usage of `nack`, the `autoDeadLetter` option, and the new matchers. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R99-R132) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R230-R251)

**Testing:**
* Added unit tests for the new `nack` behavior, auto-dead-lettering, and the new matchers, including snapshot tests for matcher failure cases. [[1]](diffhunk://#diff-776b872451e064c32f29cc2e4be1721c68ee3bcfb96926d011db821782ef5832R282-R336) [[2]](diffhunk://#diff-2d1832b02df9e5c7c94e46cf590a6ebf5b3edf4d77f4713125c44e1fa2a6fbc2R1-R28) [[3]](diffhunk://#diff-36e9040e48037daa6a47be24c2940f91a7aade9b4fd57854d3aa049c2af3ed38R1-R31) [[4]](diffhunk://#diff-f49c29fd091b1e6b4080f56e436e116e966b32a541095db93677375a3e07d472R1-R10) [[5]](diffhunk://#diff-c85fa73395b6d4c3f4287be6bb8d290d5c57c604c8380713e9a0fa5acadca4f9R1-R12)

These changes enhance the testability of message processing logic by allowing precise assertions about messages that are dead-lettered, either manually or due to handler failures.